### PR TITLE
HydraUSB3_Blink_ULED: contribute Makefile

### DIFF
--- a/HydraUSB3_Blink_ULED/Makefile
+++ b/HydraUSB3_Blink_ULED/Makefile
@@ -4,55 +4,24 @@ COMPILER_PREFIX ?= riscv-none-embed
 
 PROJECT = HydraUSB3_Blink_ULED
 
-# BSP
-C_SRCS += ../SRC/RVMSIS/core_riscv.c
-OBJS   += core_riscv.o
+RVMSIS_DIR   = ../SRC/RVMSIS
+RVMSIS_SRCS  = $(wildcard $(RVMSIS_DIR)/*.c)
+OBJS        += $(patsubst $(RVMSIS_DIR)/%.c,%.o,$(RVMSIS_SRCS))
 
-C_SRCS += \
-../SRC/Peripheral/src/CH56x_bsp.c \
-../SRC/Peripheral/src/CH56x_bus8.c \
-../SRC/Peripheral/src/CH56x_clk.c \
-../SRC/Peripheral/src/CH56x_debug_log.c \
-../SRC/Peripheral/src/CH56x_dvp.c \
-../SRC/Peripheral/src/CH56x_ecdc.c \
-../SRC/Peripheral/src/CH56x_emmc.c \
-../SRC/Peripheral/src/CH56x_flash.c \
-../SRC/Peripheral/src/CH56x_gpio.c \
-../SRC/Peripheral/src/CH56x_hspi.c \
-../SRC/Peripheral/src/CH56x_hydrausb3.c \
-../SRC/Peripheral/src/CH56x_pwm.c \
-../SRC/Peripheral/src/CH56x_pwr.c \
-../SRC/Peripheral/src/CH56x_serdes.c \
-../SRC/Peripheral/src/CH56x_spi.c \
-../SRC/Peripheral/src/CH56x_sys.c \
-../SRC/Peripheral/src/CH56x_timer.c \
-../SRC/Peripheral/src/CH56x_uart.c
+PERIPH_DIR   = ../SRC/Peripheral
+PERIPH_SRCS  = $(wildcard $(PERIPH_DIR)/src/*.c)
+OBJS        += $(patsubst $(PERIPH_DIR)/src/%.c,%.o,$(PERIPH_SRCS))
 
-OBJS += \
-  CH56x_bsp.o \
-  CH56x_bus8.o \
-  CH56x_clk.o \
-  CH56x_debug_log.o \
-  CH56x_dvp.o \
-  CH56x_ecdc.o \
-  CH56x_emmc.o \
-  CH56x_flash.o \
-  CH56x_gpio.o \
-  CH56x_hspi.o \
-  CH56x_hydrausb3.o \
-  CH56x_pwm.o \
-  CH56x_pwr.o \
-  CH56x_serdes.o \
-  CH56x_spi.o \
-  CH56x_sys.o \
-  CH56x_timer.o \
-  CH56x_uart.o
+USER_DIR     = ./User
+USER_SRCS    = $(wildcard $(USER_DIR)/*.c)
+OBJS        += $(patsubst $(USER_DIR)/%.c,%.o,$(USER_SRCS))
+
+C_SRCS = $(RVMSIS_SRCS) $(PERIPH_SRCS) $(USER_SRCS)
 
 # All of the sources participating in the build are defined here
-C_SRCS += ./User/Main.c
-OBJS   += Main.o startup_CH56x.o
-DEPS   = $(subst .o,.d,$(OBJS))
-LIBS   =
+OBJS += startup_CH56x.o
+DEPS  = $(subst .o,.d,$(OBJS))
+LIBS  =
 
 DEBUG  = -g -DDEBUG=1
 C_OPTS = -march=rv32imac -mabi=ilp32 -msmall-data-limit=8 -mno-save-restore -O3 \
@@ -60,10 +29,9 @@ C_OPTS = -march=rv32imac -mabi=ilp32 -msmall-data-limit=8 -mno-save-restore -O3 
          $(INCLUDES) $(DEBUG) -std=gnu99 -MMD -MP -MT"$(@)"
 
 INCLUDES = \
-  -I"../SRC/RVMSIS" \
-  -I"../SRC/Peripheral/inc" \
-  -I"../SRC/Startup" \
-  -I"../SRC/Peripheral/inc"
+  -I"$(RVMSIS_DIR)" \
+  -I"$(PERIPH_DIR)/inc" \
+  -I"../SRC/Startup"
 
 # Add inputs and outputs from these tool invocations to the build variables
 SECONDARY_FLASH += \
@@ -91,6 +59,7 @@ startup_CH56x.o: ../SRC/Startup/startup_CH56x.S
 	@echo ' '
 
 %.o: ./User/%.c
+	@echo $(OBJS)
 	@echo 'Building file: $<'
 	$(COMPILER_PREFIX)-gcc $(C_OPTS) -c -o "$@" "$<"
 	@echo ' '
@@ -106,7 +75,7 @@ startup_CH56x.o: ../SRC/Startup/startup_CH56x.S
 	@echo ' '
 
 # Tool invocations
-$(PROJECT).elf: $(OBJS) $(USER_OBJS)
+$(PROJECT).elf: $(OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: GNU RISC-V Cross C Linker'
 	$(COMPILER_PREFIX)-gcc -march=rv32imac -mabi=ilp32 -msmall-data-limit=8 -mno-save-restore -O3 -fmessage-length=0 -fsigned-char -ffunction-sections -fdata-sections  -g -T ".ld" -nostartfiles -Xlinker --gc-sections  -Xlinker --print-memory-usage -Wl,-Map,"$(PROJECT).map" --specs=nano.specs --specs=nosys.specs -o "$(PROJECT).elf" $(OBJS) $(LIBS)

--- a/HydraUSB3_Blink_ULED/Makefile
+++ b/HydraUSB3_Blink_ULED/Makefile
@@ -1,0 +1,143 @@
+RM := rm -rf
+
+COMPILER_PREFIX ?= riscv-none-embed
+
+# BSP
+C_SRCS += ../SRC/RVMSIS/core_riscv.c
+OBJS   += core_riscv.o
+
+C_SRCS += \
+../SRC/Peripheral/src/CH56x_bsp.c \
+../SRC/Peripheral/src/CH56x_bus8.c \
+../SRC/Peripheral/src/CH56x_clk.c \
+../SRC/Peripheral/src/CH56x_debug_log.c \
+../SRC/Peripheral/src/CH56x_dvp.c \
+../SRC/Peripheral/src/CH56x_ecdc.c \
+../SRC/Peripheral/src/CH56x_emmc.c \
+../SRC/Peripheral/src/CH56x_flash.c \
+../SRC/Peripheral/src/CH56x_gpio.c \
+../SRC/Peripheral/src/CH56x_hspi.c \
+../SRC/Peripheral/src/CH56x_hydrausb3.c \
+../SRC/Peripheral/src/CH56x_pwm.c \
+../SRC/Peripheral/src/CH56x_pwr.c \
+../SRC/Peripheral/src/CH56x_serdes.c \
+../SRC/Peripheral/src/CH56x_spi.c \
+../SRC/Peripheral/src/CH56x_sys.c \
+../SRC/Peripheral/src/CH56x_timer.c \
+../SRC/Peripheral/src/CH56x_uart.c
+
+OBJS += \
+  CH56x_bsp.o \
+  CH56x_bus8.o \
+  CH56x_clk.o \
+  CH56x_debug_log.o \
+  CH56x_dvp.o \
+  CH56x_ecdc.o \
+  CH56x_emmc.o \
+  CH56x_flash.o \
+  CH56x_gpio.o \
+  CH56x_hspi.o \
+  CH56x_hydrausb3.o \
+  CH56x_pwm.o \
+  CH56x_pwr.o \
+  CH56x_serdes.o \
+  CH56x_spi.o \
+  CH56x_sys.o \
+  CH56x_timer.o \
+  CH56x_uart.o
+
+# All of the sources participating in the build are defined here
+C_SRCS += ./User/Main.c
+OBJS   += Main.o startup_CH56x.o
+DEPS   = $(subst .o,.d,$(OBJS))
+LIBS   =
+
+DEBUG  = -g -DDEBUG=1
+C_OPTS = -march=rv32imac -mabi=ilp32 -msmall-data-limit=8 -mno-save-restore -O3 \
+         -fmessage-length=0 -fsigned-char -ffunction-sections -fdata-sections \
+         $(INCLUDES) $(DEBUG) -std=gnu99 -MMD -MP -MT"$(@)"
+
+INCLUDES = \
+  -I"../SRC/RVMSIS" \
+  -I"../SRC/Peripheral/inc" \
+  -I"../SRC/Startup" \
+  -I"../SRC/Peripheral/inc"
+
+# Add inputs and outputs from these tool invocations to the build variables
+SECONDARY_FLASH += \
+HydraUSB3_Blink_ULED.hex \
+HydraUSB3_Blink_ULED.bin \
+
+SECONDARY_LIST += \
+HydraUSB3_Blink_ULED.lst \
+
+SECONDARY_SIZE += \
+HydraUSB3_Blink_ULED.siz \
+
+SECONDARY_MAP += \
+HydraUSB3_Blink_ULED.map \
+
+SECONDARY_OUTPUTS = $(SECONDARY_FLASH) $(SECONDARY_LIST) $(SECONDARY_SIZE) $(SECONDARY_MAP)
+secondary-outputs: $(SECONDARY_OUTPUTS)
+
+# All Target
+all: HydraUSB3_Blink_ULED.elf secondary-outputs
+
+startup_CH56x.o: ../SRC/Startup/startup_CH56x.S
+	@echo 'Building file: $<'
+	$(COMPILER_PREFIX)-gcc $(C_OPTS) -x assembler -c -o "$@" "$<"
+	@echo ' '
+
+%.o: ./User/%.c
+	@echo 'Building file: $<'
+	$(COMPILER_PREFIX)-gcc $(C_OPTS) -c -o "$@" "$<"
+	@echo ' '
+
+%.o: ../SRC/RVMSIS/%.c
+	@echo 'Building file: $<'
+	$(COMPILER_PREFIX)-gcc $(C_OPTS) -c -o "$@" "$<"
+	@echo ' '
+
+%.o: ../SRC/Peripheral/src/%.c
+	@echo 'Building file: $<'
+	$(COMPILER_PREFIX)-gcc $(C_OPTS) -c -o "$@" "$<"
+	@echo ' '
+
+# Tool invocations
+HydraUSB3_Blink_ULED.elf: $(OBJS) $(USER_OBJS)
+	@echo 'Building target: $@'
+	@echo 'Invoking: GNU RISC-V Cross C Linker'
+	$(COMPILER_PREFIX)-gcc -march=rv32imac -mabi=ilp32 -msmall-data-limit=8 -mno-save-restore -O3 -fmessage-length=0 -fsigned-char -ffunction-sections -fdata-sections  -g -T ".ld" -nostartfiles -Xlinker --gc-sections  -Xlinker --print-memory-usage -Wl,-Map,"HydraUSB3_Blink_ULED.map" --specs=nano.specs --specs=nosys.specs -o "HydraUSB3_Blink_ULED.elf" $(OBJS) $(LIBS)
+	@echo 'Finished building target: $@'
+	@echo ' '
+	$(MAKE) --no-print-directory post-build
+
+HydraUSB3_Blink_ULED.hex: HydraUSB3_Blink_ULED.elf
+	@echo 'Invoking: GNU RISC-V Cross Create Flash Image'
+	$(COMPILER_PREFIX)-objcopy -O ihex "HydraUSB3_Blink_ULED.elf"  "HydraUSB3_Blink_ULED.hex"
+	@echo 'Finished building: $@'
+	@echo ' '
+
+HydraUSB3_Blink_ULED.lst: HydraUSB3_Blink_ULED.elf
+	@echo 'Invoking: GNU RISC-V Cross Create Listing'
+	$(COMPILER_PREFIX)-objdump --source --all-headers --demangle --line-numbers --wide "HydraUSB3_Blink_ULED.elf" > "HydraUSB3_Blink_ULED.lst"
+	@echo 'Finished building: $@'
+	@echo ' '
+
+HydraUSB3_Blink_ULED.siz: HydraUSB3_Blink_ULED.elf
+	@echo 'Invoking: GNU RISC-V Cross Print Size'
+	$(COMPILER_PREFIX)-size --format=berkeley "HydraUSB3_Blink_ULED.elf"
+	@echo 'Finished building: $@'
+	@echo ' '
+
+# Other Targets
+clean:
+	-$(RM) $(OBJS) $(DEPS) $(SECONDARY_OUTPUTS) HydraUSB3_Blink_ULED.elf
+	-@echo ' '
+
+post-build:
+	-@echo 'Create Flash Image BIN'
+	-$(COMPILER_PREFIX)-objcopy -O binary "HydraUSB3_Blink_ULED.elf"  "HydraUSB3_Blink_ULED.bin"
+	-@echo ' '
+
+.PHONY: all clean dependents post-build

--- a/HydraUSB3_Blink_ULED/Makefile
+++ b/HydraUSB3_Blink_ULED/Makefile
@@ -77,18 +77,20 @@ startup_CH56x.o: ../SRC/Startup/startup_CH56x.S
 
 # Tool invocations
 $(PROJECT).elf: $(OBJS)
-	@echo 'Building target: $@'
 	@echo 'Invoking: GNU RISC-V Cross C Linker'
 	$(COMPILER_PREFIX)-gcc $(BASE_OPTS) $(LD_OPTS) -o "$(PROJECT).elf" $(OBJS) $(LIBS)
-	@echo 'Finished building target: $@'
 	@echo ' '
-	$(MAKE) --no-print-directory post-build
 
 $(PROJECT).hex: $(PROJECT).elf
 	@echo 'Invoking: GNU RISC-V Cross Create Flash Image'
 	$(COMPILER_PREFIX)-objcopy -O ihex "$(PROJECT).elf"  "$(PROJECT).hex"
 	@echo 'Finished building: $@'
 	@echo ' '
+
+$(PROJECT).bin: $(PROJECT).elf
+	-@echo 'Create Flash Image BIN'
+	-$(COMPILER_PREFIX)-objcopy -O binary "$(PROJECT).elf"  "$(PROJECT).bin"
+	-@echo ' '
 
 $(PROJECT).lst: $(PROJECT).elf
 	@echo 'Invoking: GNU RISC-V Cross Create Listing'
@@ -107,9 +109,4 @@ clean:
 	-$(RM) $(OBJS) $(DEPS) $(SECONDARY_OUTPUTS) $(PROJECT).elf
 	-@echo ' '
 
-post-build:
-	-@echo 'Create Flash Image BIN'
-	-$(COMPILER_PREFIX)-objcopy -O binary "$(PROJECT).elf"  "$(PROJECT).bin"
-	-@echo ' '
-
-.PHONY: all clean dependents post-build
+.PHONY: all clean dependents

--- a/HydraUSB3_Blink_ULED/Makefile
+++ b/HydraUSB3_Blink_ULED/Makefile
@@ -2,6 +2,8 @@ RM := rm -rf
 
 COMPILER_PREFIX ?= riscv-none-embed
 
+PROJECT = HydraUSB3_Blink_ULED
+
 # BSP
 C_SRCS += ../SRC/RVMSIS/core_riscv.c
 OBJS   += core_riscv.o
@@ -65,23 +67,23 @@ INCLUDES = \
 
 # Add inputs and outputs from these tool invocations to the build variables
 SECONDARY_FLASH += \
-HydraUSB3_Blink_ULED.hex \
-HydraUSB3_Blink_ULED.bin \
+$(PROJECT).hex \
+$(PROJECT).bin \
 
 SECONDARY_LIST += \
-HydraUSB3_Blink_ULED.lst \
+$(PROJECT).lst \
 
 SECONDARY_SIZE += \
-HydraUSB3_Blink_ULED.siz \
+$(PROJECT).siz \
 
 SECONDARY_MAP += \
-HydraUSB3_Blink_ULED.map \
+$(PROJECT).map \
 
 SECONDARY_OUTPUTS = $(SECONDARY_FLASH) $(SECONDARY_LIST) $(SECONDARY_SIZE) $(SECONDARY_MAP)
 secondary-outputs: $(SECONDARY_OUTPUTS)
 
 # All Target
-all: HydraUSB3_Blink_ULED.elf secondary-outputs
+all: $(PROJECT).elf secondary-outputs
 
 startup_CH56x.o: ../SRC/Startup/startup_CH56x.S
 	@echo 'Building file: $<'
@@ -104,40 +106,40 @@ startup_CH56x.o: ../SRC/Startup/startup_CH56x.S
 	@echo ' '
 
 # Tool invocations
-HydraUSB3_Blink_ULED.elf: $(OBJS) $(USER_OBJS)
+$(PROJECT).elf: $(OBJS) $(USER_OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: GNU RISC-V Cross C Linker'
-	$(COMPILER_PREFIX)-gcc -march=rv32imac -mabi=ilp32 -msmall-data-limit=8 -mno-save-restore -O3 -fmessage-length=0 -fsigned-char -ffunction-sections -fdata-sections  -g -T ".ld" -nostartfiles -Xlinker --gc-sections  -Xlinker --print-memory-usage -Wl,-Map,"HydraUSB3_Blink_ULED.map" --specs=nano.specs --specs=nosys.specs -o "HydraUSB3_Blink_ULED.elf" $(OBJS) $(LIBS)
+	$(COMPILER_PREFIX)-gcc -march=rv32imac -mabi=ilp32 -msmall-data-limit=8 -mno-save-restore -O3 -fmessage-length=0 -fsigned-char -ffunction-sections -fdata-sections  -g -T ".ld" -nostartfiles -Xlinker --gc-sections  -Xlinker --print-memory-usage -Wl,-Map,"$(PROJECT).map" --specs=nano.specs --specs=nosys.specs -o "$(PROJECT).elf" $(OBJS) $(LIBS)
 	@echo 'Finished building target: $@'
 	@echo ' '
 	$(MAKE) --no-print-directory post-build
 
-HydraUSB3_Blink_ULED.hex: HydraUSB3_Blink_ULED.elf
+$(PROJECT).hex: $(PROJECT).elf
 	@echo 'Invoking: GNU RISC-V Cross Create Flash Image'
-	$(COMPILER_PREFIX)-objcopy -O ihex "HydraUSB3_Blink_ULED.elf"  "HydraUSB3_Blink_ULED.hex"
+	$(COMPILER_PREFIX)-objcopy -O ihex "$(PROJECT).elf"  "$(PROJECT).hex"
 	@echo 'Finished building: $@'
 	@echo ' '
 
-HydraUSB3_Blink_ULED.lst: HydraUSB3_Blink_ULED.elf
+$(PROJECT).lst: $(PROJECT).elf
 	@echo 'Invoking: GNU RISC-V Cross Create Listing'
-	$(COMPILER_PREFIX)-objdump --source --all-headers --demangle --line-numbers --wide "HydraUSB3_Blink_ULED.elf" > "HydraUSB3_Blink_ULED.lst"
+	$(COMPILER_PREFIX)-objdump --source --all-headers --demangle --line-numbers --wide "$(PROJECT).elf" > "$(PROJECT).lst"
 	@echo 'Finished building: $@'
 	@echo ' '
 
-HydraUSB3_Blink_ULED.siz: HydraUSB3_Blink_ULED.elf
+$(PROJECT).siz: $(PROJECT).elf
 	@echo 'Invoking: GNU RISC-V Cross Print Size'
-	$(COMPILER_PREFIX)-size --format=berkeley "HydraUSB3_Blink_ULED.elf"
+	$(COMPILER_PREFIX)-size --format=berkeley "$(PROJECT).elf"
 	@echo 'Finished building: $@'
 	@echo ' '
 
 # Other Targets
 clean:
-	-$(RM) $(OBJS) $(DEPS) $(SECONDARY_OUTPUTS) HydraUSB3_Blink_ULED.elf
+	-$(RM) $(OBJS) $(DEPS) $(SECONDARY_OUTPUTS) $(PROJECT).elf
 	-@echo ' '
 
 post-build:
 	-@echo 'Create Flash Image BIN'
-	-$(COMPILER_PREFIX)-objcopy -O binary "HydraUSB3_Blink_ULED.elf"  "HydraUSB3_Blink_ULED.bin"
+	-$(COMPILER_PREFIX)-objcopy -O binary "$(PROJECT).elf"  "$(PROJECT).bin"
 	-@echo ' '
 
 .PHONY: all clean dependents post-build

--- a/HydraUSB3_Blink_ULED/Makefile
+++ b/HydraUSB3_Blink_ULED/Makefile
@@ -84,7 +84,6 @@ $(PROJECT).elf: $(OBJS)
 $(PROJECT).hex: $(PROJECT).elf
 	@echo 'Invoking: GNU RISC-V Cross Create Flash Image'
 	$(COMPILER_PREFIX)-objcopy -O ihex "$(PROJECT).elf"  "$(PROJECT).hex"
-	@echo 'Finished building: $@'
 	@echo ' '
 
 $(PROJECT).bin: $(PROJECT).elf
@@ -95,13 +94,11 @@ $(PROJECT).bin: $(PROJECT).elf
 $(PROJECT).lst: $(PROJECT).elf
 	@echo 'Invoking: GNU RISC-V Cross Create Listing'
 	$(COMPILER_PREFIX)-objdump --source --all-headers --demangle --line-numbers --wide "$(PROJECT).elf" > "$(PROJECT).lst"
-	@echo 'Finished building: $@'
 	@echo ' '
 
 $(PROJECT).siz: $(PROJECT).elf
 	@echo 'Invoking: GNU RISC-V Cross Print Size'
 	$(COMPILER_PREFIX)-size --format=berkeley "$(PROJECT).elf"
-	@echo 'Finished building: $@'
 	@echo ' '
 
 # Other Targets

--- a/HydraUSB3_Blink_ULED/Makefile
+++ b/HydraUSB3_Blink_ULED/Makefile
@@ -23,10 +23,11 @@ OBJS += startup_CH56x.o
 DEPS  = $(subst .o,.d,$(OBJS))
 LIBS  =
 
-DEBUG  = -g -DDEBUG=1
-C_OPTS = -march=rv32imac -mabi=ilp32 -msmall-data-limit=8 -mno-save-restore -O3 \
-         -fmessage-length=0 -fsigned-char -ffunction-sections -fdata-sections \
-         $(INCLUDES) $(DEBUG) -std=gnu99 -MMD -MP -MT"$(@)"
+DEBUG       = -g -DDEBUG=1
+BASE_OPTS   = -march=rv32imac -mabi=ilp32 -msmall-data-limit=8 -mno-save-restore -O3 -fmessage-length=0 -fsigned-char -ffunction-sections -fdata-sections
+C_OPTS      = $(BASE_OPTS) $(DEBUG) \
+              $(INCLUDES) -std=gnu99 -MMD -MP -MT"$(@)"
+LD_OPTS     = -T ".ld" -nostartfiles -Xlinker --gc-sections  -Xlinker --print-memory-usage -Wl,-Map,"$(PROJECT).map" --specs=nano.specs --specs=nosys.specs
 
 INCLUDES = \
   -I"$(RVMSIS_DIR)" \
@@ -78,7 +79,7 @@ startup_CH56x.o: ../SRC/Startup/startup_CH56x.S
 $(PROJECT).elf: $(OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: GNU RISC-V Cross C Linker'
-	$(COMPILER_PREFIX)-gcc -march=rv32imac -mabi=ilp32 -msmall-data-limit=8 -mno-save-restore -O3 -fmessage-length=0 -fsigned-char -ffunction-sections -fdata-sections  -g -T ".ld" -nostartfiles -Xlinker --gc-sections  -Xlinker --print-memory-usage -Wl,-Map,"$(PROJECT).map" --specs=nano.specs --specs=nosys.specs -o "$(PROJECT).elf" $(OBJS) $(LIBS)
+	$(COMPILER_PREFIX)-gcc $(BASE_OPTS) $(LD_OPTS) -o "$(PROJECT).elf" $(OBJS) $(LIBS)
 	@echo 'Finished building target: $@'
 	@echo ' '
 	$(MAKE) --no-print-directory post-build

--- a/HydraUSB3_Blink_ULED/Makefile
+++ b/HydraUSB3_Blink_ULED/Makefile
@@ -35,18 +35,10 @@ INCLUDES = \
   -I"../SRC/Startup"
 
 # Add inputs and outputs from these tool invocations to the build variables
-SECONDARY_FLASH += \
-$(PROJECT).hex \
-$(PROJECT).bin \
-
-SECONDARY_LIST += \
-$(PROJECT).lst \
-
-SECONDARY_SIZE += \
-$(PROJECT).siz \
-
-SECONDARY_MAP += \
-$(PROJECT).map \
+SECONDARY_FLASH += $(PROJECT).hex $(PROJECT).bin
+SECONDARY_LIST  += $(PROJECT).lst
+SECONDARY_SIZE  += $(PROJECT).siz
+SECONDARY_MAP   += $(PROJECT).map
 
 SECONDARY_OUTPUTS = $(SECONDARY_FLASH) $(SECONDARY_LIST) $(SECONDARY_SIZE) $(SECONDARY_MAP)
 secondary-outputs: $(SECONDARY_OUTPUTS)


### PR DESCRIPTION
This allows to build with make.
To help make find the compiler, 
you need to add the toolchain to the PATH variable, for example:
```
export PATH=$PATH:/opt/MounRiver_Studio_Community_Linux_x64_V120/MRS_Community/toolchain/RISC-V\ Embedded\ GCC/bin
```